### PR TITLE
Other way to generate the boolean arrays

### DIFF
--- a/transpiler/src/main/java/java2typescript/helper/TypeHelper.java
+++ b/transpiler/src/main/java/java2typescript/helper/TypeHelper.java
@@ -136,6 +136,8 @@ public class TypeHelper {
             return "Float64Array";
         } else if (type.toString().contains("byte[]")) {
             return "Int8Array";
+        } else if(type.toString().contains("boolean[]")) {
+            return "Array<boolean>";
         }
         return null;
     }

--- a/transpiler/src/test/resources/arrays/output.ts
+++ b/transpiler/src/test/resources/arrays/output.ts
@@ -32,7 +32,7 @@ export class DoubleArray {
         }
       }
     };
-    let _back_colors: boolean[] = [];
+    let _back_colors: Array<boolean> = new Array<boolean>(10);
   }
   public sortTest(): void {
     let arr: Int32Array = new Int32Array([0, 1, 2, 3, 4]);


### PR DESCRIPTION
Boolean array can need to be initialized with a specified length (as for the bool array in GreyCat - should come soon)
For example, it is used to manually check the array bounds 

The `boolean[] = []` do not allow this, as it does not initialize the array with a length.
This is why I modify the generated code to map boolean array to Array<boolean> (as it is the case for the other primitives type :) ) 